### PR TITLE
Color Format Strings

### DIFF
--- a/themes/min-dark.json
+++ b/themes/min-dark.json
@@ -42,7 +42,7 @@
 		"statusBar.foreground": "#7E7E7E",
 		"statusBar.noFolderBackground": "#1A1A1A",
 		"statusBarItem.remoteForeground": "#7E7E7E",
-        "statusBarItem.remoteBackground": "#1a1a1a00",
+		"statusBarItem.remoteBackground": "#1a1a1a00",
 		"statusBarItem.prominentBackground": "#fafafa1a",
 		"tab.activeBorder": "#1e1e1e",
 		"tab.activeForeground": "#FAFAFA",
@@ -163,6 +163,8 @@
 		{
 			"scope": [
 				"constant.numeric",
+				"constant.other.placeholder",
+				"constant.character.format.placeholder",
 				"meta.property-value",
 				"keyword.other.unit",
 				"keyword.other.template",

--- a/themes/min-light.json
+++ b/themes/min-light.json
@@ -52,7 +52,7 @@
 		"statusBar.foreground": "#7E7E7E",
 		"statusBar.noFolderBackground": "#f6f6f6",
 		"statusBarItem.remoteForeground": "#7E7E7E",
-        "statusBarItem.remoteBackground": "#f6f6f600",
+		"statusBarItem.remoteBackground": "#f6f6f600",
 		"statusBarItem.prominentBackground": "#0000001a",
 		"tab.activeBorder": "#FFF",
 		"tab.activeForeground": "#424242",
@@ -175,6 +175,8 @@
 			"scope": [
 				"constant.numeric",
 				"constant.language",
+				"constant.other.placeholder",
+				"constant.character.format.placeholder",
 				"variable.language.this",
 				"variable.other.object",
 				"variable.other.class",


### PR DESCRIPTION
Hi @misolori, this PR adds the same color to format strings as to numeric values. 

`constant.other.placeholder` adds support to languages such as C and Go, while `constant.character.format.placeholder` is needed for Python.

Before:
![screen1](https://user-images.githubusercontent.com/3458786/81433587-1481d980-9165-11ea-9946-c64eb65d397a.png)
After:
![screen2](https://user-images.githubusercontent.com/3458786/81433596-19df2400-9165-11ea-9b19-1c12dfea47e4.png)
