### PR TITLE
Change pickerGroup.border color to be consistent

### DIFF
--- a/themes/min-dark.json
+++ b/themes/min-dark.json
@@ -31,7 +31,7 @@
 		"panelTitle.inactiveForeground": "#484848",
 		"peekView.border": "#444",
 		"peekViewEditor.background": "#242424",
-		"pickerGroup.border": "#363636",
+		"pickerGroup.border": "#383838",
 		"pickerGroup.foreground": "#EAEAEA",
 		"progressBar.background": "#FAFAFA",
 		"scrollbar.shadow": "#1f1f1f",


### PR DESCRIPTION
Surely this was meant to be 383838 ? 363636 Is the first instance of this color in the theme so for consistency I think 3838383 was meant instead. 