### PR TITLE
Fixing YAML Colors

### DIFF
--- a/themes/min-dark.json
+++ b/themes/min-dark.json
@@ -168,6 +168,7 @@
 				"meta.property-value",
 				"keyword.other.unit",
 				"keyword.other.template",
+				"entity.name.tag.yaml",
 				"entity.other.attribute-name",
 				"support.type.property-name.json"
 			],
@@ -217,6 +218,7 @@
 				"string.regexp",
 				"string.interpolated",
 				"string.template",
+				"string.unquoted.plain.out.yaml",
 				"keyword.other.template"
 			],
 			"settings": {

--- a/themes/min-light.json
+++ b/themes/min-light.json
@@ -196,6 +196,7 @@
 				"storage.type",
 				"storage.control.clojure",
 				"entity.name.function.clojure",
+				"entity.name.tag.yaml",
 				"support.function.node",
 				"support.type.property-name.json",
 				"punctuation.separator.key-value",
@@ -233,6 +234,7 @@
 				"string.regexp",
 				"string.interpolated",
 				"string.template",
+				"string.unquoted.plain.out.yaml",
 				"keyword.other.template"
 			],
 			"settings": {


### PR DESCRIPTION
This PR improves the coloring of YAML files. It applies the same colors that are already in use for JSON files.

theme | before | after
-|-|-
**dark** | ![dark_b](https://user-images.githubusercontent.com/3458786/85862623-51139e00-b7c2-11ea-8c11-5b14f13dc247.png) | ![dark_a](https://user-images.githubusercontent.com/3458786/85862669-6092e700-b7c2-11ea-9f45-57fe80bd1915.png)
**light** | ![light_b](https://user-images.githubusercontent.com/3458786/85862728-71dbf380-b7c2-11ea-8504-dc422bc66b83.png) | ![light_a](https://user-images.githubusercontent.com/3458786/85862738-76081100-b7c2-11ea-9b84-f95a9552458e.png)

