### PR TITLE
Create Min Dark2 theme

### DIFF
--- a/themes/min-dark2.json
+++ b/themes/min-dark2.json
@@ -1,0 +1,317 @@
+{
+	"name": "Min Dark2",
+	"type": "dark",
+	"colors": {
+    "editorIndentGuide.activeBackground": "#383838",
+    "editorIndentGuide.background": "#2A2A2A",
+    "editorRuler.foreground": "#2A2A2A",
+    "editorLineNumber.foreground": "#727272",
+    "activityBar.background": "#1A1A1A",
+    "activityBar.foreground": "#7D7D7D",
+    "activityBarBadge.background": "#383838",
+    "badge.background": "#383838",
+    "badge.foreground": "#C1C1C1",
+    "button.background": "#333",
+    "editor.background": "#1f1f1f",
+    "editor.lineHighlightBorder": "#303030",
+    "editorGroupHeader.tabsBackground": "#1A1A1A",
+    "editorGroupHeader.tabsBorder": "#1A1A1A",
+    "editorSuggestWidget.background": "#1A1A1A",
+    "focusBorder": "#444",
+    "foreground": "#888888",
+    "gitDecoration.ignoredResourceForeground": "#444444",
+    "input.background": "#2A2A2A",
+    "input.foreground": "#E0E0E0",
+    "list.activeSelectionBackground": "#212121",
+    "list.activeSelectionForeground": "#F5F5F5",
+    "list.focusBackground": "#292929",
+    "list.highlightForeground": "#EAEAEA",
+    "list.hoverBackground": "#262626",
+    "list.hoverForeground": "#9E9E9E",
+    "list.inactiveSelectionBackground": "#212121",
+    "list.inactiveSelectionForeground": "#F5F5F5",
+    "panelTitle.activeBorder": "#1f1f1f",
+    "panelTitle.activeForeground": "#FAFAFA",
+    "panelTitle.inactiveForeground": "#484848",
+    "peekView.border": "#444",
+    "peekViewEditor.background": "#242424",
+    "pickerGroup.border": "#363636",
+    "pickerGroup.foreground": "#EAEAEA",
+    "progressBar.background": "#FAFAFA",
+    "scrollbar.shadow": "#1f1f1f",
+    "sideBar.background": "#1A1A1A",
+    "sideBarSectionHeader.background": "#202020",
+    "statusBar.background": "#1A1A1A",
+    "statusBar.debuggingBackground": "#1A1A1A",
+    "statusBar.foreground": "#7E7E7E",
+    "statusBar.noFolderBackground": "#1A1A1A",
+    "statusBarItem.remoteForeground": "#7E7E7E",
+    "statusBarItem.remoteBackground": "#1a1a1a00",
+    "statusBarItem.prominentBackground": "#fafafa1a",
+    "tab.activeBorder": "#1e1e1e",
+    "tab.activeForeground": "#FAFAFA",
+    "tab.border": "#1A1A1A",
+    "tab.inactiveBackground": "#1A1A1A",
+    "tab.inactiveForeground": "#727272",
+    "textLink.foreground": "#CCC",
+    "textLink.activeForeground": "#fafafa",
+    "titleBar.activeBackground": "#1A1A1A",
+    "titleBar.border": "#00000000",
+    "terminal.ansiBrightBlack": "#5c5c5c",
+    "inputOption.activeBackground": "#3a3a3a",
+    "debugIcon.continueForeground": "#FF7A84",
+    "debugIcon.disconnectForeground": "#FF7A84",
+    "debugIcon.pauseForeground": "#FF7A84",
+    "debugIcon.restartForeground": "#79b8ff",
+    "debugIcon.startForeground": "#79b8ff",
+    "debugIcon.stepBackForeground": "#FF7A84",
+    "debugIcon.stepIntoForeground": "#FF7A84",
+    "debugIcon.stepOutForeground": "#FF7A84",
+    "debugIcon.stepOverForeground": "#FF7A84",
+    "debugIcon.stopForeground": "#79b8ff",
+    "debugIcon.breakpointCurrentStackframeForeground": "#79b8ff",
+    "debugIcon.breakpointDisabledForeground": "#848484",
+    "debugIcon.breakpointForeground": "#FF7A84",
+    "debugIcon.breakpointStackframeForeground": "#79b8ff",
+    "debugIcon.breakpointUnverifiedForeground": "#848484",
+    "symbolIcon.classForeground": "#FF9800",
+    "symbolIcon.enumeratorForeground": "#FF9800",
+    "symbolIcon.eventForeground": "#FF9800",
+    "symbolIcon.methodForeground": "#b392f0",
+    "symbolIcon.constructorForeground": "#b392f0",
+    "symbolIcon.functionForeground": "#b392f0",
+    "symbolIcon.fieldForeground": "#79b8ff",
+    "symbolIcon.interfaceForeground": "#79b8ff",
+    "symbolIcon.variableForeground": "#79b8ff",
+    "symbolIcon.enumeratorMemberForeground": "#79b8ff",
+    "diffEditor.insertedTextBackground": "#3a632a4b",
+    "diffEditor.removedTextBackground": "#88063852"
+  },
+	"tokenColors": [{
+			"settings": {
+				"foreground": "#ad90e3"
+			}
+		},
+		{
+			"scope": [
+				"support.function",
+				"keyword.operator.accessor",
+				"meta.group.braces.round.function.arguments",
+				"meta.template.expression",
+				"markup.fenced_code meta.embedded.block"
+			],
+			"settings": {
+				"foreground": "#ad90e3"
+			}
+		},
+		{
+			"scope": "emphasis",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": [
+				"strong",
+				"markup.heading.markdown",
+				"markup.bold.markdown"
+			],
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#FF7A84"
+			}
+		},
+		{
+			"scope": [
+				"markup.italic.markdown"
+			],
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "meta.link.inline.markdown",
+			"settings": {
+				"fontStyle": "underline",
+				"foreground": "#1976D2"
+			}
+		},
+		{
+			"scope": [
+				"string",
+				"markup.fenced_code",
+				"markup.inline"
+			],
+			"settings": {
+				"foreground": "#9db1c5"
+			}
+		},
+		{
+			"scope": [
+				"comment",
+				"string.quoted.docstring.multi"
+			],
+			"settings": {
+				"foreground": "#6b737c"
+			}
+		},
+		{
+			"scope": [
+				"constant.language",
+				"variable.language.this",
+				"variable.other.object",
+				"variable.other.class",
+				"variable.other.constant",
+				"meta.property-name",
+				"support",
+				"string.other.link.title.markdown"
+			],
+			"settings": {
+				"foreground": "#67aeff"
+			}
+		},
+		{
+			"scope": [
+				"constant.numeric",
+				"constant.other.placeholder",
+				"constant.character.format.placeholder",
+				"meta.property-value",
+				"keyword.other.unit",
+				"keyword.other.template",
+				"entity.name.tag.yaml",
+				"entity.other.attribute-name",
+				"support.type.property-name.json"
+			],
+			"settings": {
+				"foreground": "#aaefff"
+			}
+		},
+		{
+			"scope": [
+				"keyword",
+				"storage.modifier",
+				"storage.type",
+				"storage.control.clojure",
+				"entity.name.function.clojure",
+				"support.function.node",
+				"punctuation.separator.key-value",
+				"punctuation.definition.template-expression"
+			],
+			"settings": {
+				"foreground": "#ff6a79"
+			}
+		},
+		{
+			"scope": "variable.parameter.function",
+			"settings": {
+				"foreground": "#FF9800"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.type",
+				"entity.other.inherited-class",
+				"meta.function-call",
+				"meta.instance.constructor",
+				"entity.other.attribute-name",
+				"entity.name.function",
+				"constant.keyword.clojure"
+			],
+			"settings": {
+				"foreground": "#ad90e3"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.tag",
+				"string.quoted",
+				"string.regexp",
+				"string.interpolated",
+				"string.template",
+				"string.unquoted.plain.out.yaml",
+				"keyword.other.template"
+			],
+			"settings": {
+				"foreground": "#f1f99a"
+			}
+		},
+
+        {
+			"scope": [
+				"entity.name.tag"
+			],
+			"settings": {
+				"foreground": "#fc85c9"
+			}
+		},
+		{
+			"scope": "token.info-token",
+			"settings": {
+				"foreground": "#316bcd"
+			}
+		},
+		{
+			"scope": "token.warn-token",
+			"settings": {
+				"foreground": "#cd9731"
+			}
+		},
+		{
+			"scope": "token.error-token",
+			"settings": {
+				"foreground": "#cd3131"
+			}
+		},
+		{
+			"scope": "token.debug-token",
+			"settings": {
+				"foreground": "#800080"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.definition.arguments",
+				"punctuation.definition.dict",
+				"punctuation.separator",
+				"meta.function-call.arguments"
+			],
+			"settings": {
+				"foreground": "#bbbbbb"
+			}
+		},
+		{
+			"name": "[Custom] Markdown links",
+			"scope": "markup.underline.link",
+			"settings": {
+				"foreground": "#f1f99a"
+			}
+		},
+		{
+			"name": "[Custom] Markdown list",
+			"scope": [
+				"beginning.punctuation.definition.list.markdown"
+			],
+			"settings": {
+				"foreground": "#FF7A84"
+			}
+		},
+		{
+			"name": "[Custom] Markdown punctuation definition",
+			"scope": "punctuation.definition.metadata.markdown",
+			"settings": {
+				"foreground": "#f1f99a"
+			}
+		},
+		{
+			"name": "[Custom] Markdown punctuation definition brackets",
+			"scope": [
+				"punctuation.definition.string.begin.markdown",
+				"punctuation.definition.string.end.markdown"
+			],
+			"settings": {
+				"foreground": "#79b8ff"
+			}
+		}
+	],
+	"semanticHighlighting": true
+}


### PR DESCRIPTION
Min dark is a theme I love to use in VS Code. But I would like to use some specific colors for syntax highlighting in the editor. I customized the editor's syntax highlighting color setting, and affectionately called it Min Dark2. I think the colors used are really cool, and Min Dark2 can be very useful as just another color option for people who, like me, love using the Min Theme.

Thanks!

![3](https://user-images.githubusercontent.com/59850744/220233022-750845b2-3cea-454f-ac2e-234081b41b3f.png)

![min-dark2](https://user-images.githubusercontent.com/59850744/220230970-ae247030-45e0-4a80-b20a-3d9c6b80df47.png)

![2](https://user-images.githubusercontent.com/59850744/220233050-bd3d0cc8-2e42-4341-8d21-b772f17f81a2.png)

![4](https://user-images.githubusercontent.com/59850744/220233059-90cd0f9a-2cdb-47e0-b3eb-45f3705e49f8.png)

